### PR TITLE
Fix bug with keywords which are a prefix of others

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@
                 }
             }
 
-            output[state].push(word);
+            output[curr].push(word);
         });
 
         var failure = {};


### PR DESCRIPTION
It looks like there was a minor bug where the keyword was put into the wrong place in the output when it was a prefix of another keyword.

Sample test case which showed the problem:

```js
var ac = new AhoCorasick(['hero', 'heroic']);
ac.search('hero');

// Expected:
[1, ["hero"]]

// Actual
[]
```